### PR TITLE
Pass extra context if provided to email_invite template

### DIFF
--- a/invitations/forms.py
+++ b/invitations/forms.py
@@ -16,8 +16,7 @@ class InviteForm(AddEmailForm):
                                  " invited."),
         }
 
-        if Invitation.objects.filter(email__iexact=value,
-                                     accepted=False):
+        if Invitation.objects.filter(email__iexact=value).exists():
             raise forms.ValidationError(errors["already_invited"])
 
         return value

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -56,6 +56,9 @@ class Invitation(models.Model):
             'email': self.email,
             'key': self.key,
         }
+        extra_email_context = kwargs.get('extra_email_context', {})
+        if extra_email_context and isinstance(extra_email_context, dict):
+            ctx.update(extra_email_context)
 
         email_template = 'invitations/email/email_invite'
 


### PR DESCRIPTION
User can supply `extra_email_context` to be used in `email_invite` template. It is necessary because its a common use case that another user from the site is inviting someone. We need to tell the invitee that who is inviting you.

```
invite = form.save(email)
invite.send_invitation(self.request, extra_email_context={'from': user})
```

Doing so we can use `from` user in templates.