### PR TITLE
Allow using custom allauth backends.

### DIFF
--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -108,8 +108,9 @@ class BaseInvitationsAdapter(object):
 
 
 def get_invitations_adapter():
-    if hasattr(settings, 'ACCOUNT_ADAPTER'):
-        if settings.ACCOUNT_ADAPTER == 'invitations.models.InvitationsAdapter':
+    # Compatibility with legacy allauth only version.
+    if (hasattr(settings, 'ACCOUNT_ADAPTER') and
+        settings.ACCOUNT_ADAPTER == 'invitations.models.InvitationsAdapter'):
             # defer to allauth
             from allauth.account.adapter import get_adapter
             return get_adapter()

--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -109,11 +109,12 @@ class BaseInvitationsAdapter(object):
 
 def get_invitations_adapter():
     # Compatibility with legacy allauth only version.
-    if (hasattr(settings, 'ACCOUNT_ADAPTER') and
-        settings.ACCOUNT_ADAPTER == 'invitations.models.InvitationsAdapter'):
-            # defer to allauth
-            from allauth.account.adapter import get_adapter
-            return get_adapter()
+    LEGACY_ALLAUTH = hasattr(settings, 'ACCOUNT_ADAPTER') and \
+        settings.ACCOUNT_ADAPTER == 'invitations.models.InvitationsAdapter'
+    if LEGACY_ALLAUTH:
+        # defer to allauth
+        from allauth.account.adapter import get_adapter
+        return get_adapter()
     else:
         # load an adapter from elsewhere
         return import_attribute(app_settings.ADAPTER)()


### PR DESCRIPTION
This ensures that `get_invitations_adapter` will not return `None` if you have `ACCOUNT_ADAPTER` set but it is *not* set to `'invitations.models.InvitationsAdapter'`.

Fixes #28 