### PR TITLE
Remove RemovedInDjango110Warning warnings in Django 1.9

### DIFF
--- a/invitations/urls.py
+++ b/invitations/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     url(r'^send-invite/$', views.SendInvite.as_view(),
         name='send-invite'),
 
@@ -13,4 +11,4 @@ urlpatterns = patterns(
 
     url(r'^accept-invite/(?P<key>\w+)/?$', views.AcceptInvite.as_view(),
         name='accept-invite'),
-)
+]


### PR DESCRIPTION
With Django 1.9, each time I run `python manage.py runserver`, it shows 2 warnings:

```
/someplace/.venv/lib/python2.7/site-packages/invitations/urls.py:15: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name='accept-invite'),

/someplace/.venv/lib/python2.7/site-packages/invitations/urls.py:15: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name='accept-invite'),
```

This pull request fixes it.