### PR TITLE
Display a message on expired/erroneous/accepted keys. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
 
     Boolean. If confirmations can be accepted via a `GET` request.
 
+*   `INVITATIONS_GONE_ON_ACCEPT_ERROR` (default=`True`)
+
+    Boolean. If `True`, return an HTTP 410 GONE response if the invitation key
+    is invalid, or the invitation is expired or previously accepted when
+    accepting an invite. If `False`, display an error message and redirect on
+    errors:
+
+        * Redirects to `INVITATIONS_SIGNUP_REDIRECT` on an expired key
+        * Otherwise, redirects to `INVITATIONS_LOGIN_REDIRECT` on other errors.
+
 *   `INVITATIONS_ALLOW_JSON_INVITES` (default=`False`)
 
     Expose a URL for authenticated posting of invitees
@@ -85,6 +95,10 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
 *   `INVITATIONS_SIGNUP_REDIRECT` (default=`'account_signup'`)
 
     URL name of your signup URL.
+
+*   `INVITATIONS_LOGIN_REDIRECT` (default=`LOGIN_URL` from Django settings)
+
+    URL name of your login URL.
 
 *  `INVITATIONS_ADAPTER` (default=`'invitations.adapters.BaseInvitationsAdapter'`)
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
     accepting an invite. If `False`, display an error message and redirect on
     errors:
 
-        * Redirects to `INVITATIONS_SIGNUP_REDIRECT` on an expired key
-        * Otherwise, redirects to `INVITATIONS_LOGIN_REDIRECT` on other errors.
+    * Redirects to `INVITATIONS_SIGNUP_REDIRECT` on an expired key
+    * Otherwise, redirects to `INVITATIONS_LOGIN_REDIRECT` on other errors.
 
 *   `INVITATIONS_ALLOW_JSON_INVITES` (default=`False`)
 

--- a/invitations/app_settings.py
+++ b/invitations/app_settings.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 class AppSettings(object):
 
     def __init__(self, prefix):
@@ -23,6 +25,14 @@ class AppSettings(object):
         return self._setting('CONFIRM_INVITE_ON_GET', True)
 
     @property
+    def GONE_ON_ACCEPT_ERROR(self):
+        """
+        If an invalid/expired/previously accepted key is provided, return a
+        HTTP 410 GONE response.
+        """
+        return self._setting('GONE_ON_ACCEPT_ERROR', True)
+
+    @property
     def ALLOW_JSON_INVITES(self):
         """ Exposes json endpoint for mass invite creation """
         return self._setting('ALLOW_JSON_INVITES', False)
@@ -31,6 +41,11 @@ class AppSettings(object):
     def SIGNUP_REDIRECT(self):
         """ Where to redirect on email confirm of invite """
         return self._setting('SIGNUP_REDIRECT', 'account_signup')
+
+    @property
+    def LOGIN_REDIRECT(self):
+        """ Where to redirect on an expired or already accepted invite """
+        return self._setting('LOGIN_REDIRECT', settings.LOGIN_URL)
 
     @property
     def ADAPTER(self):

--- a/invitations/app_settings.py
+++ b/invitations/app_settings.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+
 class AppSettings(object):
 
     def __init__(self, prefix):

--- a/invitations/templates/invitations/messages/invite_already_accepted.txt
+++ b/invitations/templates/invitations/messages/invite_already_accepted.txt
@@ -1,0 +1,1 @@
+The invitation for {{ email }} was already accepted.

--- a/invitations/templates/invitations/messages/invite_expired.txt
+++ b/invitations/templates/invitations/messages/invite_expired.txt
@@ -1,0 +1,1 @@
+The invitation for {{ email }} has expired.

--- a/invitations/templates/invitations/messages/invite_invalid.txt
+++ b/invitations/templates/invitations/messages/invite_invalid.txt
@@ -1,0 +1,1 @@
+An invalid invitation key was submitted.

--- a/invitations/tests/allauth/test_allauth.py
+++ b/invitations/tests/allauth/test_allauth.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from nose_parameterized import parameterized
 from allauth.account.models import EmailAddress
@@ -20,6 +21,8 @@ class AllAuthIntegrationTests(TestCase):
             password='password')
         cls.invitation = Invitation.create(
             'email@example.com', inviter=cls.user)
+        cls.invitation.sent = timezone.now()
+        cls.invitation.save()
         cls.adapter = get_invitations_adapter()
 
     @classmethod

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -99,12 +99,13 @@ class AcceptInvite(SingleObjectMixin, View):
     def post(self, *args, **kwargs):
         self.object = invitation = self.get_object()
 
-        # Compatibility with older versions: return an HTTP 410 GONE if there is
-        # an error. # Error conditions are: no key, expired key or previously
-        # accepted key.
+        # Compatibility with older versions: return an HTTP 410 GONE if there
+        # is an error. # Error conditions are: no key, expired key or
+        # previously accepted key.
         if app_settings.GONE_ON_ACCEPT_ERROR and \
-                (not invitation or (invitation and (invitation.accepted or
-                                                    invitation.key_expired()))):
+                (not invitation or
+                 (invitation and (invitation.accepted or
+                                  invitation.key_expired()))):
             return HttpResponse(status=410)
 
         # No invitation was found.


### PR DESCRIPTION
Related to #25, similar to #26.

This makes the following changes:
* Adds a new configuration `INVITATIONS_GONE_ON_ACCEPT_ERROR`, defaults to the 'old' behavior of returning an HTTP 410 response on errors.
* If `INVITATIONS_GONE_ON_ACCEPT_ERROR` is `False`, uses messages to tell the user what happened (invalid key, expired key, already accepted key) and redirects.
* Adds a configurable `INVITATIONS_LOGIN_REDIRECT` setting.
* Include tests and documentation.

Please let me know if you'd like to see any changes to this or have any questions.