### PR TITLE
add EMAIL_SUBJECT_PREFIX setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
 
     Used for custom integrations. Set this to `ACCOUNT_ADAPTER` if using django-allauth.
 
+*  `INVITATIONS_EMAIL_SUBJECT_PREFIX` (default=`None`)
+
+    If set to `None` (the defualt), the subject in emails will be prefixed with the name of the current Site in brackets (such as `[example.com]`). Set this to a string to for a custom email subject prefix, or an empty string for no subject prefix.
+
 ###Signals
 
 The following signals are emitted:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
 
 *  `INVITATIONS_EMAIL_SUBJECT_PREFIX` (default=`None`)
 
-    If set to `None` (the defualt), the subject in emails will be prefixed with the name of the current Site in brackets (such as `[example.com]`). Set this to a string to for a custom email subject prefix, or an empty string for no subject prefix.
+    If set to `None` (the default), invitation email subjects will be prefixed with the name of the current Site in brackets (such as `[example.com]`). Set this to a string to for a custom email subject prefix, or an empty string for no prefix.
 
 ###Signals
 

--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -26,8 +26,10 @@ class BaseInvitationsAdapter(object):
         return ret
 
     def format_email_subject(self, subject):
-        site = Site.objects.get_current()
-        prefix = "[{name}] ".format(name=site.name)
+        prefix = app_settings.EMAIL_SUBJECT_PREFIX
+        if prefix is None:
+            site = Site.objects.get_current()
+            prefix = "[{name}] ".format(name=site.name)
         return prefix + force_text(subject)
 
     def render_mail(self, template_prefix, email, context):

--- a/invitations/app_settings.py
+++ b/invitations/app_settings.py
@@ -54,4 +54,11 @@ class AppSettings(object):
         return self._setting(
             'ADAPTER', 'invitations.adapters.BaseInvitationsAdapter')
 
+    @property
+    def EMAIL_SUBJECT_PREFIX(self):
+        """
+        Subject-line prefix to use for email messages sent
+        """
+        return self._setting("EMAIL_SUBJECT_PREFIX", None)
+
 app_settings = AppSettings('INVITATIONS_')

--- a/invitations/tests/basic/tests.py
+++ b/invitations/tests/basic/tests.py
@@ -72,9 +72,9 @@ class InvitationsAdapterTests(TestCase):
             result = self.adapter.format_email_subject("Bar")
             self.assertEqual(result, '[Foo.com] Bar')
         # custom override
-        with self.settings(INVITATIONS_EMAIL_SUBJECT_PREFIX="Foo: "):
+        with self.settings(INVITATIONS_EMAIL_SUBJECT_PREFIX=""):
             result = self.adapter.format_email_subject("Bar")
-            self.assertEqual(result, "Foo: Bar")
+            self.assertEqual(result, "Bar")
 
 
 class InvitationsSendViewTests(TestCase):

--- a/invitations/tests/basic/tests.py
+++ b/invitations/tests/basic/tests.py
@@ -65,6 +65,17 @@ class InvitationsAdapterTests(TestCase):
     def test_fetch_adapter(self):
         self.assertIsInstance(self.adapter, BaseInvitationsAdapter)
 
+    def test_email_subject_prefix_settings(self):
+        # default
+        with patch('invitations.adapters.Site') as MockSite:
+            MockSite.objects.get_current.return_value.name = 'Foo.com'
+            result = self.adapter.format_email_subject("Bar")
+            self.assertEqual(result, '[Foo.com] Bar')
+        # custom override
+        with self.settings(INVITATIONS_EMAIL_SUBJECT_PREFIX="Foo: "):
+            result = self.adapter.format_email_subject("Bar")
+            self.assertEqual(result, "Foo: Bar")
+
 
 class InvitationsSendViewTests(TestCase):
 


### PR DESCRIPTION
This would close https://github.com/bee-keeper/django-invitations/issues/40

This PR adds an app setting, `INVITATIONS_EMAIL_SUBJECT_PREFIX`, that allows people to override the subject prefix in email invitations, similar to `ALLAUTH_EMAIL_SUBJECT_PREFIX`. I included a test, but I'm having trouble setting up the test environment properly on my local computer.