### PR TITLE
Add option to accept invite after signup for allauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
 
     Boolean. If confirmations can be accepted via a `GET` request.
 
+*   `INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP` (default=`False`)
+
+    Boolean. If `True`, invitations will be accepted after users finish signup.
+    If `False`, invitations will be accepted right after the invitation link is clicked.
+
 *   `INVITATIONS_GONE_ON_ACCEPT_ERROR` (default=`True`)
 
     Boolean. If `True`, return an HTTP 410 GONE response if the invitation key

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Bulk invites are supported via JSON.  Post a list of comma separated emails to t
 
     Boolean. If `True`, invitations will be accepted after users finish signup.
     If `False`, invitations will be accepted right after the invitation link is clicked.
+    Note that this only works with Allauth for now, which means `ACCOUNT_ADAPTER` has to be
+    `'invitations.models.InvitationsAdapter'`.
 
 *   `INVITATIONS_GONE_ON_ACCEPT_ERROR` (default=`True`)
 

--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
-from allauth.account.signals import user_signed_up
-
 from .app_settings import app_settings
 from .utils import import_attribute
 
@@ -109,9 +107,6 @@ class BaseInvitationsAdapter(object):
                                          extra_tags=extra_tags)
             except TemplateDoesNotExist:
                 pass
-
-    def get_user_signed_up_signal(self):
-        return user_signed_up
 
 
 def get_invitations_adapter():

--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
+from allauth.account.signals import user_signed_up
+
 from .app_settings import app_settings
 from .utils import import_attribute
 
@@ -107,6 +109,9 @@ class BaseInvitationsAdapter(object):
                                          extra_tags=extra_tags)
             except TemplateDoesNotExist:
                 pass
+
+    def get_user_signed_up_signal(self):
+        return user_signed_up
 
 
 def get_invitations_adapter():

--- a/invitations/app_settings.py
+++ b/invitations/app_settings.py
@@ -26,6 +26,11 @@ class AppSettings(object):
         return self._setting('CONFIRM_INVITE_ON_GET', True)
 
     @property
+    def ACCEPT_INVITE_AFTER_SIGNUP(self):
+        """ Accept the invitation after the user finished signup. """
+        return self._setting('ACCEPT_INVITE_AFTER_SIGNUP', False)
+
+    @property
     def GONE_ON_ACCEPT_ERROR(self):
         """
         If an invalid/expired/previously accepted key is provided, return a

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -10,8 +10,6 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.template.context import RequestContext
 
-from allauth.account.signals import user_signed_up
-
 from .managers import InvitationManager
 from .app_settings import app_settings
 from .adapters import get_invitations_adapter
@@ -85,6 +83,7 @@ class Invitation(models.Model):
 if hasattr(settings, 'ACCOUNT_ADAPTER'):
     if settings.ACCOUNT_ADAPTER == 'invitations.models.InvitationsAdapter':
         from allauth.account.adapter import DefaultAccountAdapter
+        from allauth.account.signals import user_signed_up
 
         class InvitationsAdapter(DefaultAccountAdapter):
 

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -10,6 +10,8 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.template.context import RequestContext
 
+from allauth.account.signals import user_signed_up
+
 from .managers import InvitationManager
 from .app_settings import app_settings
 from .adapters import get_invitations_adapter
@@ -96,3 +98,6 @@ if hasattr(settings, 'ACCOUNT_ADAPTER'):
                 else:
                     # Site is open to signup
                     return True
+
+            def get_user_signed_up_signal(self):
+                return user_signed_up

--- a/invitations/tests/allauth/test_allauth.py
+++ b/invitations/tests/allauth/test_allauth.py
@@ -72,7 +72,7 @@ class AllAuthIntegrationTests(TestCase):
     @override_settings(
         INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP=True,
     )
-    def test_accept_invite_accepted_invitation_after_allauth_signup(self, method):
+    def test_accept_invite_accepted_invitation_after_signup(self, method):
         client_with_method = getattr(self.client, method)
         resp = client_with_method(
             reverse('invitations:accept-invite',

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -176,9 +176,8 @@ def accept_invitation(invitation, request, signal_sender):
 if app_settings.ACCEPT_INVITE_AFTER_SIGNUP:
 
     def accept_invite_after_signup(sender, request, user, **kwargs):
-        if Invitation.objects.filter(email=user.email).exists():
-            invitation = Invitation.objects.get(email=user.email)
-            if invitation:
-                accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
+        invitation = Invitation.objects.filter(email=user.email).first()
+        if invitation:
+            accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
 
     user_signed_up.connect(accept_invite_after_signup)

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -7,14 +7,12 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.dispatch import receiver
 
 from allauth.account.signals import user_signed_up
 from braces.views import LoginRequiredMixin
 
 from .forms import InviteForm, CleanEmailMixin
 from .models import Invitation
-from . import signals
 from .exceptions import AlreadyInvited, AlreadyAccepted, UserRegisteredEmail
 from .app_settings import app_settings
 from .adapters import get_invitations_adapter

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -176,7 +176,7 @@ def accept_invitation(invitation, request, signal_sender):
 
 
 @receiver(user_signed_up)
-def accept_invite(sender, request, user, **kwargs):
+def accept_invite_after_signup(sender, request, user, **kwargs):
     if Invitation.objects.filter(email=user.email).exists():
         invitation = Invitation.objects.get(email=user.email)
         if invitation:

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -175,9 +175,12 @@ def accept_invitation(invitation, request, signal_sender):
         {'email': invitation.email})
 
 
-@receiver(user_signed_up)
-def accept_invite_after_signup(sender, request, user, **kwargs):
-    if Invitation.objects.filter(email=user.email).exists():
-        invitation = Invitation.objects.get(email=user.email)
-        if invitation:
-            accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
+if app_settings.ACCEPT_INVITE_AFTER_SIGNUP:
+
+    def accept_invite_after_signup(sender, request, user, **kwargs):
+        if Invitation.objects.filter(email=user.email).exists():
+            invitation = Invitation.objects.get(email=user.email)
+            if invitation:
+                accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
+
+    user_signed_up.connect(accept_invite_after_signup)

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -8,7 +8,6 @@ from django.shortcuts import redirect
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 
-from allauth.account.signals import user_signed_up
 from braces.views import LoginRequiredMixin
 
 from .forms import InviteForm, CleanEmailMixin
@@ -179,4 +178,4 @@ def accept_invite_after_signup(sender, request, user, **kwargs):
         accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
 
 if app_settings.ACCEPT_INVITE_AFTER_SIGNUP:
-    user_signed_up.connect(accept_invite_after_signup)
+    get_invitations_adapter().get_user_signed_up_signal().connect(accept_invite_after_signup)

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -148,10 +148,6 @@ class AcceptInvite(SingleObjectMixin, View):
         get_invitations_adapter().stash_verified_email(
             self.request, invitation.email)
 
-        signals.invite_accepted.send(sender=self.__class__,
-                                     request=self.request,
-                                     email=invitation.email)
-
         return redirect(app_settings.SIGNUP_REDIRECT)
 
     def get_object(self, queryset=None):

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -173,11 +173,10 @@ def accept_invitation(invitation, request, signal_sender):
         {'email': invitation.email})
 
 
+def accept_invite_after_signup(sender, request, user, **kwargs):
+    invitation = Invitation.objects.filter(email=user.email).first()
+    if invitation:
+        accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
+
 if app_settings.ACCEPT_INVITE_AFTER_SIGNUP:
-
-    def accept_invite_after_signup(sender, request, user, **kwargs):
-        invitation = Invitation.objects.filter(email=user.email).first()
-        if invitation:
-            accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
-
     user_signed_up.connect(accept_invite_after_signup)

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -138,9 +138,12 @@ class AcceptInvite(SingleObjectMixin, View):
             # Redirect to sign-up since they might be able to register anyway.
             return redirect(app_settings.SIGNUP_REDIRECT)
 
-        # The invitation is valid. Mark it as accepted now if ACCEPT_INVITE_AFTER_SIGNUP is False.
+        # The invitation is valid.
+        # Mark it as accepted now if ACCEPT_INVITE_AFTER_SIGNUP is False.
         if not app_settings.ACCEPT_INVITE_AFTER_SIGNUP:
-            accept_invitation(invitation=invitation, request=self.request, signal_sender=self.__class__)
+            accept_invitation(invitation=invitation,
+                              request=self.request,
+                              signal_sender=self.__class__)
 
         get_invitations_adapter().stash_verified_email(
             self.request, invitation.email)
@@ -175,7 +178,10 @@ def accept_invitation(invitation, request, signal_sender):
 def accept_invite_after_signup(sender, request, user, **kwargs):
     invitation = Invitation.objects.filter(email=user.email).first()
     if invitation:
-        accept_invitation(invitation=invitation, request=request, signal_sender=Invitation)
+        accept_invitation(invitation=invitation,
+                          request=request,
+                          signal_sender=Invitation)
 
 if app_settings.ACCEPT_INVITE_AFTER_SIGNUP:
-    get_invitations_adapter().get_user_signed_up_signal().connect(accept_invite_after_signup)
+    signed_up_signal = get_invitations_adapter().get_user_signed_up_signal()
+    signed_up_signal.connect(accept_invite_after_signup)


### PR DESCRIPTION
This PR is to solve the problem addressed in this issue #bee-keeper#25

The change is: a setting variable INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP is added. When it's True, invitations will be accepted after users finish signup. When it's False, invitations will be accepted right after the invitation link is clicked. 

Note that this behavior only works with allauth.