### PR TITLE
Fix deprecation warnings

### DIFF
--- a/invitations/migrations/0002_auto_20151126_0426.py
+++ b/invitations/migrations/0002_auto_20151126_0426.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 from django.conf import settings
 
 EMAIL_MAX_LENGTH = getattr(settings, 'INVITATIONS_EMAIL_MAX_LENGTH', 254)
@@ -19,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='invitation',
             name='inviter',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AlterField(
             model_name='invitation',

--- a/invitations/migrations/0003_auto_20151126_1523.py
+++ b/invitations/migrations/0003_auto_20151126_1523.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 from django.conf import settings
 
 
@@ -15,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='invitation',
             name='inviter',
-            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
     ]

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -6,9 +6,12 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.template.context import RequestContext
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 from .managers import InvitationManager
 from .app_settings import app_settings

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -26,8 +26,8 @@ class Invitation(models.Model):
                                    default=timezone.now)
     key = models.CharField(verbose_name=_('key'), max_length=64, unique=True)
     sent = models.DateTimeField(verbose_name=_('sent'), null=True)
-    inviter = models.ForeignKey(
-        settings.AUTH_USER_MODEL, null=True, blank=True)
+    inviter = models.ForeignKey(settings.AUTH_USER_MODEL, null=True,
+                                blank=True, on_delete=models.CASCADE)
 
     objects = InvitationManager()
 


### PR DESCRIPTION
Deprecation warnings are being displayed after upgrading to Django 1.10.5. This PR fixes two of the deprecations:

- `on_delete` will be a required arg for ForeignKey in Django 2.0. https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete
- Importing from django.core.urlresolvers is deprecated in favor of django.urls. I fixed this with a `try` statement so that it doesn't break backwards compatibility with old Django versions.

There are a couple other warnings involving deprecated usage of `django.conf.urls.include()`, but I'm not sure how to fix those since this is a reusable Django app.

## Testing Steps

To test this, I installed Django 1.10.5 and added `DEBUG = True` to `test_settings.py`. I then ran `python -Wd manage.py runserver` which will display the deprecation warnings. After making my changes the deprecation warnings were no longer displayed.