### PR TITLE
Added get_signup_redirect to allow custom implementations by subclasses

### DIFF
--- a/invitations/views.py
+++ b/invitations/views.py
@@ -90,6 +90,9 @@ class SendJSONInvite(LoginRequiredMixin, View):
 class AcceptInvite(SingleObjectMixin, View):
     form_class = InviteForm
 
+    def get_signup_redirect(self):
+        return app_settings.SIGNUP_REDIRECT
+
     def get(self, *args, **kwargs):
         if app_settings.CONFIRM_INVITE_ON_GET:
             return self.post(*args, **kwargs)
@@ -136,7 +139,7 @@ class AcceptInvite(SingleObjectMixin, View):
                 'invitations/messages/invite_expired.txt',
                 {'email': invitation.email})
             # Redirect to sign-up since they might be able to register anyway.
-            return redirect(app_settings.SIGNUP_REDIRECT)
+            return redirect(self.get_signup_redirect())
 
         # The invitation is valid.
         # Mark it as accepted now if ACCEPT_INVITE_AFTER_SIGNUP is False.
@@ -148,7 +151,7 @@ class AcceptInvite(SingleObjectMixin, View):
         get_invitations_adapter().stash_verified_email(
             self.request, invitation.email)
 
-        return redirect(app_settings.SIGNUP_REDIRECT)
+        return redirect(self.get_signup_redirect())
 
     def get_object(self, queryset=None):
         if queryset is None:


### PR DESCRIPTION
I find it quite useful to implement the custom redirect as a function in a subclass of `AcceptInvite`, so that we can redirect to a signup form and pass e.g. the invite ID. I'm not sure if others use this pattern but, if so, this change will allow it (I couldn't find any way of doing it before).