### PR TITLE
Adds missing migrations step to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ pip install django-invitations
 
 # Append to urls.py
 url(r'^invitations/', include('invitations.urls', namespace='invitations')),
+
+# Run migrations
+
+python manage.py migrate
 ```
 
 ### Allauth Integration


### PR DESCRIPTION
Hi,

Thanks for building this tool. This just adds a required step to the instructions in the README. Without running migrate, users won't be able to use the admin.

Thanks,

Michael