### PR TITLE
Fix deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install django-invitations
 'invitations',
 
 # Append to urls.py
-url(r'^invitations/', include('invitations.urls', namespace='invitations')),
+url(r'^invitations/', include('invitations.urls')),
 
 # Run migrations
 

--- a/invitations/base_invitation.py
+++ b/invitations/base_invitation.py
@@ -12,7 +12,7 @@ class AbstractBaseInvitation(models.Model):
     key = models.CharField(verbose_name=_('key'), max_length=64, unique=True)
     sent = models.DateTimeField(verbose_name=_('sent'), null=True)
     inviter = models.ForeignKey(
-        settings.AUTH_USER_MODEL, null=True, blank=True)
+        settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)
 
     objects = BaseInvitationManager()
 

--- a/invitations/urls.py
+++ b/invitations/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'invitations'
 urlpatterns = [
     url(r'^send-invite/$', views.SendInvite.as_view(),
         name='send-invite'),

--- a/test_settings.py
+++ b/test_settings.py
@@ -45,6 +45,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/test_urls.py
+++ b/test_urls.py
@@ -5,9 +5,8 @@ from django.conf import settings
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^invitations/', include(
-        'invitations.urls', namespace='invitations')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^invitations/', include('invitations.urls')),
+    url(r'^admin/', admin.site.urls),
 ]
 
 if 'allauth' in settings.INSTALLED_APPS:


### PR DESCRIPTION
This fixes a bunch of deprecation warnings, most of them are for Django 2.0, but a couple are for Django 1.10.

I can break this into separate PRs if you'd like.

I also wasn't sure how far back in Django versions that is supported by this library...hopefully I didn't break anything!