### PR TITLE
Add namespace for invitations to urls.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install django-invitations
 'invitations',
 
 # Append to urls.py
-url(r'^invitations/', include('invitations.urls')),
+url(r'^invitations/', include('invitations.urls', namespace='invitations')),
 
 # Run migrations
 


### PR DESCRIPTION
This is missing in the documentation which causes first time users to get a namespace error. This fixes that issue.