### PR TITLE
Ignore email case when accepting invites after signup

### DIFF
--- a/invitations/views.py
+++ b/invitations/views.py
@@ -188,7 +188,7 @@ def accept_invitation(invitation, request, signal_sender):
 
 
 def accept_invite_after_signup(sender, request, user, **kwargs):
-    invitation = Invitation.objects.filter(email=user.email).first()
+    invitation = Invitation.objects.filter(email__iexact=user.email).first()
     if invitation:
         accept_invitation(invitation=invitation,
                           request=request,


### PR DESCRIPTION
When using django-allauth and `ACCEPT_INVITE_AFTER_SIGNUP`, the `Invitation` object is obtained by using the new `User`'s email address. Even if a user signs up with an email that differs from the one used on the invite, allauth will normally still associate the `Invitation` email address with the new `User`.

If a user simply alters the case of the email address during signup (user@example.com -> USER@EXAMPLE.COM), allauth's `cleanup_email_addresses()` function can result in the new `User` email matching the case given during signup, rather than the case used on the invite. This will cause the invite to never properly be accepted, as the current implementation of `accept_invite_after_signup()` does not ignore case. 