### PR TITLE
MANIFEST.in: Include usual targets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
+include LICENSE ChangeLog README.md requirements.txt manage.py tox.ini
 recursive-include invitations/templates *
+include test_*.py
+recursive-include tests *.py


### PR DESCRIPTION
Fixes https://github.com/bee-keeper/django-invitations/issues/119