### PR TITLE
Update url() to re_path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install django-invitations
 'invitations',
 
 # Append to urls.py
-url(r'^invitations/', include('invitations.urls', namespace='invitations')),
+re_path(r'^invitations/', include('invitations.urls', namespace='invitations')),
 
 # Run migrations
 


### PR DESCRIPTION
url() is an alias for re_path() and is likely to be deprecated in a future release. 

https://docs.djangoproject.com/en/2.2/ref/urls/#url