### PR TITLE
Remove six now that Python2 is not supported

### DIFF
--- a/invitations/base_invitation.py
+++ b/invitations/base_invitation.py
@@ -1,12 +1,10 @@
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from .managers import BaseInvitationManager
 
 
-@python_2_unicode_compatible
 class AbstractBaseInvitation(models.Model):
     accepted = models.BooleanField(verbose_name=_('accepted'), default=False)
     key = models.CharField(verbose_name=_('key'), max_length=64, unique=True)

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -9,7 +9,6 @@ except ImportError:
 from django.db import models
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from . import signals
@@ -18,7 +17,6 @@ from .app_settings import app_settings
 from .base_invitation import AbstractBaseInvitation
 
 
-@python_2_unicode_compatible
 class Invitation(AbstractBaseInvitation):
     email = models.EmailField(unique=True, verbose_name=_('e-mail address'),
                               max_length=app_settings.EMAIL_MAX_LENGTH)

--- a/invitations/utils.py
+++ b/invitations/utils.py
@@ -1,6 +1,5 @@
 from django.apps import apps as django_apps
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 from .app_settings import app_settings
 
@@ -11,7 +10,7 @@ except ImportError:
 
 
 def import_attribute(path):
-    assert isinstance(path, six.string_types)
+    assert isinstance(path, str)
     pkg, attr = path.rsplit('.', 1)
     ret = getattr(importlib.import_module(pkg), attr)
     return ret


### PR DESCRIPTION
As of this commit https://github.com/bee-keeper/django-invitations/commit/3ff9f466a0d18a4bc175efba1c63af5e91a61ca9

- Python2 is no longer being tested.
- The PyPI classifiers do not include Python2