### PR TITLE
Added resend action to admin (Closes #263)

### DIFF
--- a/invitations/admin.py
+++ b/invitations/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
 from .utils import (
     get_invitation_admin_add_form,
@@ -15,6 +16,7 @@ InvitationAdminChangeForm = get_invitation_admin_change_form()
 class InvitationAdmin(admin.ModelAdmin):
     list_display = ("email", "sent", "accepted")
     autocomplete_fields = ["inviter"]
+    actions = ["resend_invitation"]
 
     def get_form(self, request, obj=None, **kwargs):
         if obj:
@@ -24,3 +26,9 @@ class InvitationAdmin(admin.ModelAdmin):
             kwargs["form"].user = request.user
             kwargs["form"].request = request
         return super().get_form(request, obj, **kwargs)
+
+    @admin.action(description=_("Resend invitation"))
+    def resend_invitation(self, request, queryset):
+        for invitation in queryset:
+            invitation.send_invitation(request)
+        self.message_user(request, _("Selected invitations have been resent."))


### PR DESCRIPTION
Closes #263

Added a resend action to the admin that (as the name suggests) sends again the email.

Notes:
1. How to handle the po files? 
2. This just resends the email, the key of the invitation is the same
3. Since the `sent` datetime is updated, if expiration is activated in the project, it means that expiration period is also reset. i.e. the user will have x days to activate by the time of resend, if expiry is set to x days.
4. pre-commit last step was failing on my system `pycln`. Not sure why, but I don't thing it is related to the changes I made.