### PR TITLE
Fix link markup in contributing guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,7 +3,7 @@ Contributing
 
 JazzBand project
 ----------------
-As we are members of a [JazzBand project](https://jazzband.co/projects), `django-invitations` contributors should adhere to the [Contributor Code of Conduct](https://jazzband.co/about/conduct).
+As we are members of a `JazzBand project <https://jazzband.co/projects>`_, `django-invitations` contributors should adhere to the `Contributor Code of Conduct <https://jazzband.co/about/conduct>`_.
 
 
 Testing


### PR DESCRIPTION
Convert from markdown style link to rst link because the doc is in rst.